### PR TITLE
Remove createJSModules override annotation

### DIFF
--- a/android/src/main/java/com/hariharanweb/xzing/ZxingPackage.java
+++ b/android/src/main/java/com/hariharanweb/xzing/ZxingPackage.java
@@ -17,7 +17,6 @@ public class ZxingPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
`createJSModules` has been removed since RN 0.47. Removal of the `@Override` annotation allows running the code on RN 0.47 and older versions.